### PR TITLE
feat: 数据预处理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 dist-ssr
 *.local
+json-server

--- a/package.json
+++ b/package.json
@@ -12,13 +12,19 @@
 		"changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
 	},
 	"dependencies": {
+		"@ant-design/icons-vue": "^6.0.1",
 		"@types/codemirror": "^5.60.5",
 		"ant-design-vue": "^2.2.8",
 		"axios": "^0.25.0",
 		"codemirror": "^5.65.1",
+		"default-passive-events": "^2.0.0",
+		"mathjs": "^10.1.1",
 		"pinia": "^2.0.0-rc.10",
 		"vue": "^3.2.25",
-		"vue-router": "4"
+		"vue-router": "4",
+		"vxe-table": "^4.1.20",
+		"webpack-env": "^0.8.0",
+		"xe-utils": "^3.5.4"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^16.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
+  '@ant-design/icons-vue': ^6.0.1
   '@commitlint/cli': ^16.0.3
   '@commitlint/config-conventional': ^16.0.0
   '@types/codemirror': ^5.60.5
@@ -15,6 +16,7 @@ specifiers:
   conventional-changelog-cli: ^2.2.2
   cross-env: ^7.0.2
   dart-sass: ^1.25.0
+  default-passive-events: ^2.0.0
   eslint: ^8.7.0
   eslint-config-airbnb-base: ^15.0.0
   eslint-config-prettier: ^8.3.0
@@ -24,6 +26,7 @@ specifiers:
   husky: ^7.0.4
   less: ^4.1.2
   lint-staged: ^12.2.0
+  mathjs: ^10.1.1
   mrm: ^3.0.10
   pinia: ^2.0.0-rc.10
   prettier: ^2.5.1
@@ -35,15 +38,24 @@ specifiers:
   vue: ^3.2.25
   vue-router: '4'
   vue-tsc: ^0.29.8
+  vxe-table: ^4.1.20
+  webpack-env: ^0.8.0
+  xe-utils: ^3.5.4
 
 dependencies:
+  '@ant-design/icons-vue': 6.0.1_vue@3.2.27
   '@types/codemirror': registry.npmmirror.com/@types/codemirror/5.60.5
   ant-design-vue: registry.npmmirror.com/ant-design-vue/2.2.8_1d3c0f59c01af099101b44516eefc99f
   axios: registry.npmmirror.com/axios/0.25.0
   codemirror: registry.npmmirror.com/codemirror/5.65.1
+  default-passive-events: 2.0.0
+  mathjs: 10.1.1
   pinia: registry.npmmirror.com/pinia/2.0.0-rc.10_typescript@4.5.4+vue@3.2.27
   vue: registry.npmmirror.com/vue/3.2.27
   vue-router: registry.npmmirror.com/vue-router/4.0.12_vue@3.2.27
+  vxe-table: 4.1.20_vue@3.2.27+xe-utils@3.5.4
+  webpack-env: 0.8.0
+  xe-utils: 3.5.4
 
 devDependencies:
   '@commitlint/cli': registry.npmmirror.com/@commitlint/cli/16.0.3_@types+node@17.0.10
@@ -75,6 +87,1558 @@ devDependencies:
   vue-tsc: registry.npmmirror.com/vue-tsc/0.29.8_typescript@4.5.4
 
 packages:
+  /@ant-design/colors/5.1.1:
+    resolution: { integrity: sha512-Txy4KpHrp3q4XZdfgOBqLl+lkQIc3tEvHXOimRN1giX1AEC7mGtyrO9p8iRGJ3FLuVMGa2gNEzQyghVymLttKQ== }
+    dependencies:
+      '@ctrl/tinycolor': 3.4.0
+    dev: false
+
+  /@ant-design/icons-svg/4.2.1:
+    resolution: { integrity: sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw== }
+    dev: false
+
+  /@ant-design/icons-vue/6.0.1_vue@3.2.27:
+    resolution: { integrity: sha512-HigIgEVV6bbcrz2A92/qDzi/aKWB5EC6b6E1mxMB6aQA7ksiKY+gi4U94TpqyEIIhR23uaDrjufJ+xCZQ+vx6Q== }
+    peerDependencies:
+      vue: '>=3.0.3'
+    dependencies:
+      '@ant-design/colors': 5.1.1
+      '@ant-design/icons-svg': 4.2.1
+      '@types/lodash': 4.14.178
+      lodash: 4.17.21
+      vue: registry.npmmirror.com/vue/3.2.27
+    dev: false
+
+  /@babel/runtime/7.16.7:
+    resolution: { integrity: sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ== }
+    engines: { node: '>=6.9.0' }
+    dependencies:
+      regenerator-runtime: 0.13.9
+    dev: false
+
+  /@ctrl/tinycolor/3.4.0:
+    resolution: { integrity: sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ== }
+    engines: { node: '>=10' }
+    dev: false
+
+  /@types/lodash/4.14.178:
+    resolution: { integrity: sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw== }
+    dev: false
+
+  /acorn/3.3.0:
+    resolution: { integrity: sha1-ReN/s56No/JbruP/U2niu18iAXo= }
+    engines: { node: '>=0.4.0' }
+    hasBin: true
+    dev: false
+
+  /align-text/0.1.4:
+    resolution: { integrity: sha1-DNkKVhCT810KmSVsIrcGlDP60Rc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+      longest: 1.0.1
+      repeat-string: 1.6.1
+    dev: false
+
+  /amdefine/1.0.1:
+    resolution: { integrity: sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU= }
+    engines: { node: '>=0.4.2' }
+    dev: false
+
+  /anymatch/1.3.2:
+    resolution: { integrity: sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA== }
+    dependencies:
+      micromatch: 2.3.11
+      normalize-path: 2.1.1
+    dev: false
+
+  /arr-diff/2.0.0:
+    resolution: { integrity: sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-flatten: 1.1.0
+    dev: false
+
+  /arr-diff/4.0.0:
+    resolution: { integrity: sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /arr-flatten/1.1.0:
+    resolution: { integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /arr-union/3.1.0:
+    resolution: { integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /array-unique/0.2.1:
+    resolution: { integrity: sha1-odl8yvy8JiXMcPrc6zalDFiwGlM= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /array-unique/0.3.2:
+    resolution: { integrity: sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /assert/1.5.0:
+    resolution: { integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA== }
+    dependencies:
+      object-assign: 4.1.1
+      util: 0.10.3
+    dev: false
+
+  /assign-symbols/1.0.0:
+    resolution: { integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /async-each/1.0.3:
+    resolution: { integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ== }
+    dev: false
+
+  /async/0.2.10:
+    resolution: { integrity: sha1-trvgsGdLnXGXCMo43owjfLUmw9E= }
+    dev: false
+
+  /async/0.9.2:
+    resolution: { integrity: sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0= }
+    dev: false
+
+  /async/1.5.2:
+    resolution: { integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo= }
+    dev: false
+
+  /atob/2.1.2:
+    resolution: { integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg== }
+    engines: { node: '>= 4.5.0' }
+    hasBin: true
+    dev: false
+
+  /base/0.11.2:
+    resolution: { integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      cache-base: 1.0.1
+      class-utils: 0.3.6
+      component-emitter: 1.3.0
+      define-property: 1.0.0
+      isobject: 3.0.1
+      mixin-deep: 1.3.2
+      pascalcase: 0.1.1
+    dev: false
+
+  /base64-js/1.5.1:
+    resolution: { integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA== }
+    dev: false
+
+  /big.js/3.2.0:
+    resolution: { integrity: sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q== }
+    dev: false
+
+  /binary-extensions/1.13.1:
+    resolution: { integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /bindings/1.5.0:
+    resolution: { integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ== }
+    dependencies:
+      file-uri-to-path: 1.0.0
+    dev: false
+    optional: true
+
+  /braces/1.8.5:
+    resolution: { integrity: sha1-uneWLhLf+WnWt2cR6RS3N4V79qc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      expand-range: 1.8.2
+      preserve: 0.2.0
+      repeat-element: 1.1.4
+    dev: false
+
+  /braces/2.3.2:
+    resolution: { integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-flatten: 1.1.0
+      array-unique: 0.3.2
+      extend-shallow: 2.0.1
+      fill-range: 4.0.0
+      isobject: 3.0.1
+      repeat-element: 1.1.4
+      snapdragon: 0.8.2
+      snapdragon-node: 2.1.1
+      split-string: 3.1.0
+      to-regex: 3.0.2
+    dev: false
+
+  /browserify-aes/0.4.0:
+    resolution: { integrity: sha1-BnFJtmjfMcS1hTPgLQHoBthgjiw= }
+    dependencies:
+      inherits: 2.0.4
+    dev: false
+
+  /browserify-zlib/0.1.4:
+    resolution: { integrity: sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0= }
+    dependencies:
+      pako: 0.2.9
+    dev: false
+
+  /buffer/4.9.2:
+    resolution: { integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg== }
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
+    dev: false
+
+  /builtin-status-codes/3.0.0:
+    resolution: { integrity: sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug= }
+    dev: false
+
+  /cache-base/1.0.1:
+    resolution: { integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      collection-visit: 1.0.0
+      component-emitter: 1.3.0
+      get-value: 2.0.6
+      has-value: 1.0.0
+      isobject: 3.0.1
+      set-value: 2.0.1
+      to-object-path: 0.3.0
+      union-value: 1.0.1
+      unset-value: 1.0.0
+    dev: false
+
+  /camelcase/1.2.1:
+    resolution: { integrity: sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /center-align/0.1.3:
+    resolution: { integrity: sha1-qg0yYptu6XIgBBHL1EYckHvCt60= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      align-text: 0.1.4
+      lazy-cache: 1.0.4
+    dev: false
+
+  /chokidar/1.7.0:
+    resolution: { integrity: sha1-eY5ol3gVHIB2tLNg5e3SjNortGg= }
+    deprecated: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
+    dependencies:
+      anymatch: 1.3.2
+      async-each: 1.0.3
+      glob-parent: 2.0.0
+      inherits: 2.0.4
+      is-binary-path: 1.0.1
+      is-glob: 2.0.1
+      path-is-absolute: 1.0.1
+      readdirp: 2.2.1
+    optionalDependencies:
+      fsevents: 1.2.13
+    dev: false
+
+  /class-utils/0.3.6:
+    resolution: { integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-union: 3.1.0
+      define-property: 0.2.5
+      isobject: 3.0.1
+      static-extend: 0.1.2
+    dev: false
+
+  /cliui/2.1.0:
+    resolution: { integrity: sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE= }
+    dependencies:
+      center-align: 0.1.3
+      right-align: 0.1.3
+      wordwrap: 0.0.2
+    dev: false
+
+  /clone/1.0.4:
+    resolution: { integrity: sha1-2jCcwmPfFZlMaIypAheco8fNfH4= }
+    engines: { node: '>=0.8' }
+    dev: false
+
+  /collection-visit/1.0.0:
+    resolution: { integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      map-visit: 1.0.0
+      object-visit: 1.0.1
+    dev: false
+
+  /complex.js/2.0.15:
+    resolution: { integrity: sha512-gDBvQU8IG139ZBQTSo2qvDFP+lANMGluM779csXOr6ny1NUtA3wkUnCFjlDNH/moAVfXtvClYt6G0zarFbtz5w== }
+    dev: false
+
+  /component-emitter/1.3.0:
+    resolution: { integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg== }
+    dev: false
+
+  /console-browserify/1.2.0:
+    resolution: { integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA== }
+    dev: false
+
+  /constants-browserify/1.0.0:
+    resolution: { integrity: sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U= }
+    dev: false
+
+  /copy-descriptor/0.1.1:
+    resolution: { integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /core-util-is/1.0.3:
+    resolution: { integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ== }
+    dev: false
+
+  /crypto-browserify/3.3.0:
+    resolution: { integrity: sha1-ufx1u0oO1h3PHNXa6W6zDJw+UGw= }
+    dependencies:
+      browserify-aes: 0.4.0
+      pbkdf2-compat: 2.0.1
+      ripemd160: 0.2.0
+      sha.js: 2.2.6
+    dev: false
+
+  /debug/2.6.9:
+    resolution: { integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA== }
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
+  /decamelize/1.2.0:
+    resolution: { integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /decimal.js/10.3.1:
+    resolution: { integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ== }
+    dev: false
+
+  /decode-uri-component/0.2.0:
+    resolution: { integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU= }
+    engines: { node: '>=0.10' }
+    dev: false
+
+  /default-passive-events/2.0.0:
+    resolution: { integrity: sha512-eMtt76GpDVngZQ3ocgvRcNCklUMwID1PaNbCNxfpDXuiOXttSh0HzBbda1HU9SIUsDc02vb7g9+3I5tlqe/qMQ== }
+    dev: false
+
+  /define-property/0.2.5:
+    resolution: { integrity: sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-descriptor: 0.1.6
+    dev: false
+
+  /define-property/1.0.0:
+    resolution: { integrity: sha1-dp66rz9KY6rTr56NMEybvnm/sOY= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-descriptor: 1.0.2
+    dev: false
+
+  /define-property/2.0.2:
+    resolution: { integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-descriptor: 1.0.2
+      isobject: 3.0.1
+    dev: false
+
+  /domain-browser/1.2.0:
+    resolution: { integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA== }
+    engines: { node: '>=0.4', npm: '>=1.2' }
+    dev: false
+
+  /emojis-list/2.1.0:
+    resolution: { integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k= }
+    engines: { node: '>= 0.10' }
+    dev: false
+
+  /enhanced-resolve/0.9.1:
+    resolution: { integrity: sha1-TW5omzcl+GCQknzMhs2fFjW4ni4= }
+    engines: { node: '>=0.6' }
+    dependencies:
+      graceful-fs: 4.2.9
+      memory-fs: 0.2.0
+      tapable: 0.1.10
+    dev: false
+
+  /errno/0.1.8:
+    resolution: { integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A== }
+    hasBin: true
+    dependencies:
+      prr: 1.0.1
+    dev: false
+
+  /escape-latex/1.2.0:
+    resolution: { integrity: sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw== }
+    dev: false
+
+  /events/1.1.1:
+    resolution: { integrity: sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ= }
+    engines: { node: '>=0.4.x' }
+    dev: false
+
+  /expand-brackets/0.1.5:
+    resolution: { integrity: sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-posix-bracket: 0.1.1
+    dev: false
+
+  /expand-brackets/2.1.4:
+    resolution: { integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      debug: 2.6.9
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      posix-character-classes: 0.1.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    dev: false
+
+  /expand-range/1.8.2:
+    resolution: { integrity: sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      fill-range: 2.2.4
+    dev: false
+
+  /extend-shallow/2.0.1:
+    resolution: { integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-extendable: 0.1.1
+    dev: false
+
+  /extend-shallow/3.0.2:
+    resolution: { integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      assign-symbols: 1.0.0
+      is-extendable: 1.0.1
+    dev: false
+
+  /extglob/0.3.2:
+    resolution: { integrity: sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-extglob: 1.0.0
+    dev: false
+
+  /extglob/2.0.4:
+    resolution: { integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      array-unique: 0.3.2
+      define-property: 1.0.0
+      expand-brackets: 2.1.4
+      extend-shallow: 2.0.1
+      fragment-cache: 0.2.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    dev: false
+
+  /file-uri-to-path/1.0.0:
+    resolution: { integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw== }
+    dev: false
+    optional: true
+
+  /filename-regex/2.0.1:
+    resolution: { integrity: sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /fill-range/2.2.4:
+    resolution: { integrity: sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-number: 2.1.0
+      isobject: 2.1.0
+      randomatic: 3.1.1
+      repeat-element: 1.1.4
+      repeat-string: 1.6.1
+    dev: false
+
+  /fill-range/4.0.0:
+    resolution: { integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      extend-shallow: 2.0.1
+      is-number: 3.0.0
+      repeat-string: 1.6.1
+      to-regex-range: 2.1.1
+    dev: false
+
+  /for-in/1.0.2:
+    resolution: { integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /for-own/0.1.5:
+    resolution: { integrity: sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      for-in: 1.0.2
+    dev: false
+
+  /fraction.js/4.1.2:
+    resolution: { integrity: sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA== }
+    dev: false
+
+  /fragment-cache/0.2.1:
+    resolution: { integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      map-cache: 0.2.2
+    dev: false
+
+  /fsevents/1.2.13:
+    resolution: { integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw== }
+    engines: { node: '>= 4.0' }
+    os: [darwin]
+    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    requiresBuild: true
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.15.0
+    dev: false
+    optional: true
+
+  /get-value/2.0.6:
+    resolution: { integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /glob-base/0.3.0:
+    resolution: { integrity: sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      glob-parent: 2.0.0
+      is-glob: 2.0.1
+    dev: false
+
+  /glob-parent/2.0.0:
+    resolution: { integrity: sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg= }
+    dependencies:
+      is-glob: 2.0.1
+    dev: false
+
+  /graceful-fs/4.2.9:
+    resolution: { integrity: sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ== }
+    dev: false
+
+  /has-flag/1.0.0:
+    resolution: { integrity: sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /has-value/0.3.1:
+    resolution: { integrity: sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      get-value: 2.0.6
+      has-values: 0.1.4
+      isobject: 2.1.0
+    dev: false
+
+  /has-value/1.0.0:
+    resolution: { integrity: sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      get-value: 2.0.6
+      has-values: 1.0.0
+      isobject: 3.0.1
+    dev: false
+
+  /has-values/0.1.4:
+    resolution: { integrity: sha1-bWHeldkd/Km5oCCJrThL/49it3E= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /has-values/1.0.0:
+    resolution: { integrity: sha1-lbC2P+whRmGab+V/51Yo1aOe/k8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-number: 3.0.0
+      kind-of: 4.0.0
+    dev: false
+
+  /https-browserify/0.0.1:
+    resolution: { integrity: sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI= }
+    dev: false
+
+  /ieee754/1.2.1:
+    resolution: { integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA== }
+    dev: false
+
+  /indexof/0.0.1:
+    resolution: { integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10= }
+    dev: false
+
+  /inherits/2.0.1:
+    resolution: { integrity: sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE= }
+    dev: false
+
+  /inherits/2.0.3:
+    resolution: { integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4= }
+    dev: false
+
+  /inherits/2.0.4:
+    resolution: { integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ== }
+    dev: false
+
+  /interpret/0.6.6:
+    resolution: { integrity: sha1-/s16GOfOXKar+5U+H4YhOknxYls= }
+    dev: false
+
+  /is-accessor-descriptor/0.1.6:
+    resolution: { integrity: sha1-qeEss66Nh2cn7u84Q/igiXtcmNY= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /is-accessor-descriptor/1.0.0:
+    resolution: { integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 6.0.3
+    dev: false
+
+  /is-binary-path/1.0.1:
+    resolution: { integrity: sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      binary-extensions: 1.13.1
+    dev: false
+
+  /is-buffer/1.1.6:
+    resolution: { integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w== }
+    dev: false
+
+  /is-data-descriptor/0.1.4:
+    resolution: { integrity: sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /is-data-descriptor/1.0.0:
+    resolution: { integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 6.0.3
+    dev: false
+
+  /is-descriptor/0.1.6:
+    resolution: { integrity: sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-accessor-descriptor: 0.1.6
+      is-data-descriptor: 0.1.4
+      kind-of: 5.1.0
+    dev: false
+
+  /is-descriptor/1.0.2:
+    resolution: { integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-accessor-descriptor: 1.0.0
+      is-data-descriptor: 1.0.0
+      kind-of: 6.0.3
+    dev: false
+
+  /is-dotfile/1.0.3:
+    resolution: { integrity: sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-equal-shallow/0.1.3:
+    resolution: { integrity: sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-primitive: 2.0.0
+    dev: false
+
+  /is-extendable/0.1.1:
+    resolution: { integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-extendable/1.0.1:
+    resolution: { integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-plain-object: 2.0.4
+    dev: false
+
+  /is-extglob/1.0.0:
+    resolution: { integrity: sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-glob/2.0.1:
+    resolution: { integrity: sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-extglob: 1.0.0
+    dev: false
+
+  /is-number/2.1.0:
+    resolution: { integrity: sha1-Afy7s5NGOlSPL0ZszhbezknbkI8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /is-number/3.0.0:
+    resolution: { integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /is-number/4.0.0:
+    resolution: { integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-plain-object/2.0.4:
+    resolution: { integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      isobject: 3.0.1
+    dev: false
+
+  /is-posix-bracket/0.1.1:
+    resolution: { integrity: sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-primitive/2.0.0:
+    resolution: { integrity: sha1-IHurkWOEmcB7Kt8kCkGochADRXU= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /is-windows/1.0.2:
+    resolution: { integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /isarray/1.0.0:
+    resolution: { integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE= }
+    dev: false
+
+  /isobject/2.1.0:
+    resolution: { integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      isarray: 1.0.0
+    dev: false
+
+  /isobject/3.0.1:
+    resolution: { integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /javascript-natural-sort/0.7.1:
+    resolution: { integrity: sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k= }
+    dev: false
+
+  /json5/0.5.1:
+    resolution: { integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE= }
+    hasBin: true
+    dev: false
+
+  /kind-of/3.2.2:
+    resolution: { integrity: sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-buffer: 1.1.6
+    dev: false
+
+  /kind-of/4.0.0:
+    resolution: { integrity: sha1-IIE989cSkosgc3hpGkUGb65y3Vc= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-buffer: 1.1.6
+    dev: false
+
+  /kind-of/5.1.0:
+    resolution: { integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /kind-of/6.0.3:
+    resolution: { integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /lazy-cache/1.0.4:
+    resolution: { integrity: sha1-odePw6UEdMuAhF07O24dpJpEbo4= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /loader-utils/0.2.17:
+    resolution: { integrity: sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g= }
+    dependencies:
+      big.js: 3.2.0
+      emojis-list: 2.1.0
+      json5: 0.5.1
+      object-assign: 4.1.1
+    dev: false
+
+  /lodash/4.17.21:
+    resolution: { integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg== }
+    dev: false
+
+  /longest/1.0.1:
+    resolution: { integrity: sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /map-cache/0.2.2:
+    resolution: { integrity: sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /map-visit/1.0.0:
+    resolution: { integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      object-visit: 1.0.1
+    dev: false
+
+  /math-random/1.0.4:
+    resolution: { integrity: sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A== }
+    dev: false
+
+  /mathjs/10.1.1:
+    resolution: { integrity: sha512-4QJP8a0Vy90ajFYESnITSluCrQBZnI+2XQhKJIRdo/6t95oupffS5qA4MTWnLGm5GsEZF179JSMjST7wCdZQkA== }
+    engines: { node: '>= 12' }
+    hasBin: true
+    dependencies:
+      '@babel/runtime': 7.16.7
+      complex.js: 2.0.15
+      decimal.js: 10.3.1
+      escape-latex: 1.2.0
+      fraction.js: 4.1.2
+      javascript-natural-sort: 0.7.1
+      seedrandom: 3.0.5
+      tiny-emitter: 2.1.0
+      typed-function: 2.0.0
+    dev: false
+
+  /memory-fs/0.2.0:
+    resolution: { integrity: sha1-8rslNovBIeORwlIN6Slpyu4KApA= }
+    dev: false
+
+  /memory-fs/0.3.0:
+    resolution: { integrity: sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA= }
+    dependencies:
+      errno: 0.1.8
+      readable-stream: 2.3.7
+    dev: false
+
+  /micromatch/2.3.11:
+    resolution: { integrity: sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-diff: 2.0.0
+      array-unique: 0.2.1
+      braces: 1.8.5
+      expand-brackets: 0.1.5
+      extglob: 0.3.2
+      filename-regex: 2.0.1
+      is-extglob: 1.0.0
+      is-glob: 2.0.1
+      kind-of: 3.2.2
+      normalize-path: 2.1.1
+      object.omit: 2.0.1
+      parse-glob: 3.0.4
+      regex-cache: 0.4.4
+    dev: false
+
+  /micromatch/3.1.10:
+    resolution: { integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      braces: 2.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      extglob: 2.0.4
+      fragment-cache: 0.2.1
+      kind-of: 6.0.3
+      nanomatch: 1.2.13
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    dev: false
+
+  /minimist/0.0.10:
+    resolution: { integrity: sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8= }
+    dev: false
+
+  /minimist/1.2.5:
+    resolution: { integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw== }
+    dev: false
+
+  /mixin-deep/1.3.2:
+    resolution: { integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      for-in: 1.0.2
+      is-extendable: 1.0.1
+    dev: false
+
+  /mkdirp/0.5.5:
+    resolution: { integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ== }
+    hasBin: true
+    dependencies:
+      minimist: 1.2.5
+    dev: false
+
+  /ms/2.0.0:
+    resolution: { integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g= }
+    dev: false
+
+  /nan/2.15.0:
+    resolution: { integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ== }
+    dev: false
+    optional: true
+
+  /nanomatch/1.2.13:
+    resolution: { integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      fragment-cache: 0.2.1
+      is-windows: 1.0.2
+      kind-of: 6.0.3
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    dev: false
+
+  /node-libs-browser/0.7.0:
+    resolution: { integrity: sha1-PicsCBnjCJNeJmdECNevDhSRuDs= }
+    dependencies:
+      assert: 1.5.0
+      browserify-zlib: 0.1.4
+      buffer: 4.9.2
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      crypto-browserify: 3.3.0
+      domain-browser: 1.2.0
+      events: 1.1.1
+      https-browserify: 0.0.1
+      os-browserify: 0.2.1
+      path-browserify: 0.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 2.3.7
+      stream-browserify: 2.0.2
+      stream-http: 2.8.3
+      string_decoder: 0.10.31
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.0
+      url: 0.11.0
+      util: 0.10.4
+      vm-browserify: 0.0.4
+    dev: false
+
+  /normalize-path/2.1.1:
+    resolution: { integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      remove-trailing-separator: 1.1.0
+    dev: false
+
+  /object-assign/4.1.1:
+    resolution: { integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /object-copy/0.1.0:
+    resolution: { integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      copy-descriptor: 0.1.1
+      define-property: 0.2.5
+      kind-of: 3.2.2
+    dev: false
+
+  /object-visit/1.0.1:
+    resolution: { integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      isobject: 3.0.1
+    dev: false
+
+  /object.omit/2.0.1:
+    resolution: { integrity: sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      for-own: 0.1.5
+      is-extendable: 0.1.1
+    dev: false
+
+  /object.pick/1.3.0:
+    resolution: { integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      isobject: 3.0.1
+    dev: false
+
+  /optimist/0.6.1:
+    resolution: { integrity: sha1-2j6nRob6IaGaERwybpDrFaAZZoY= }
+    dependencies:
+      minimist: 0.0.10
+      wordwrap: 0.0.3
+    dev: false
+
+  /os-browserify/0.2.1:
+    resolution: { integrity: sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8= }
+    dev: false
+
+  /pako/0.2.9:
+    resolution: { integrity: sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU= }
+    dev: false
+
+  /parse-glob/3.0.4:
+    resolution: { integrity: sha1-ssN2z7EfNVE7rdFz7wu246OIORw= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      glob-base: 0.3.0
+      is-dotfile: 1.0.3
+      is-extglob: 1.0.0
+      is-glob: 2.0.1
+    dev: false
+
+  /pascalcase/0.1.1:
+    resolution: { integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /path-browserify/0.0.0:
+    resolution: { integrity: sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo= }
+    dev: false
+
+  /path-is-absolute/1.0.1:
+    resolution: { integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /pbkdf2-compat/2.0.1:
+    resolution: { integrity: sha1-tuDI+plJTZTgURV1gCpZpcFC8og= }
+    dev: false
+
+  /posix-character-classes/0.1.1:
+    resolution: { integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /preserve/0.2.0:
+    resolution: { integrity: sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /process-nextick-args/2.0.1:
+    resolution: { integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag== }
+    dev: false
+
+  /process/0.11.10:
+    resolution: { integrity: sha1-czIwDoQBYb2j5podHZGn1LwW8YI= }
+    engines: { node: '>= 0.6.0' }
+    dev: false
+
+  /prr/1.0.1:
+    resolution: { integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY= }
+    dev: false
+
+  /punycode/1.3.2:
+    resolution: { integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0= }
+    dev: false
+
+  /punycode/1.4.1:
+    resolution: { integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4= }
+    dev: false
+
+  /querystring-es3/0.2.1:
+    resolution: { integrity: sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM= }
+    engines: { node: '>=0.4.x' }
+    dev: false
+
+  /querystring/0.2.0:
+    resolution: { integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA= }
+    engines: { node: '>=0.4.x' }
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
+
+  /randomatic/3.1.1:
+    resolution: { integrity: sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw== }
+    engines: { node: '>= 0.10.0' }
+    dependencies:
+      is-number: 4.0.0
+      kind-of: 6.0.3
+      math-random: 1.0.4
+    dev: false
+
+  /readable-stream/2.3.7:
+    resolution: { integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw== }
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+    dev: false
+
+  /readdirp/2.2.1:
+    resolution: { integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ== }
+    engines: { node: '>=0.10' }
+    dependencies:
+      graceful-fs: 4.2.9
+      micromatch: 3.1.10
+      readable-stream: 2.3.7
+    dev: false
+
+  /regenerator-runtime/0.13.9:
+    resolution: { integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA== }
+    dev: false
+
+  /regex-cache/0.4.4:
+    resolution: { integrity: sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-equal-shallow: 0.1.3
+    dev: false
+
+  /regex-not/1.0.2:
+    resolution: { integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      extend-shallow: 3.0.2
+      safe-regex: 1.1.0
+    dev: false
+
+  /remove-trailing-separator/1.1.0:
+    resolution: { integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8= }
+    dev: false
+
+  /repeat-element/1.1.4:
+    resolution: { integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /repeat-string/1.6.1:
+    resolution: { integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc= }
+    engines: { node: '>=0.10' }
+    dev: false
+
+  /resolve-url/0.2.1:
+    resolution: { integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo= }
+    deprecated: https://github.com/lydell/resolve-url#deprecated
+    dev: false
+
+  /ret/0.1.15:
+    resolution: { integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg== }
+    engines: { node: '>=0.12' }
+    dev: false
+
+  /right-align/0.1.3:
+    resolution: { integrity: sha1-YTObci/mo1FWiSENJOFMlhSGE+8= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      align-text: 0.1.4
+    dev: false
+
+  /ripemd160/0.2.0:
+    resolution: { integrity: sha1-K/GYveFnys+lHAqSjoS2i74XH84= }
+    dev: false
+
+  /safe-buffer/5.1.2:
+    resolution: { integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g== }
+    dev: false
+
+  /safe-regex/1.1.0:
+    resolution: { integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4= }
+    dependencies:
+      ret: 0.1.15
+    dev: false
+
+  /seedrandom/3.0.5:
+    resolution: { integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg== }
+    dev: false
+
+  /set-value/2.0.1:
+    resolution: { integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      extend-shallow: 2.0.1
+      is-extendable: 0.1.1
+      is-plain-object: 2.0.4
+      split-string: 3.1.0
+    dev: false
+
+  /setimmediate/1.0.5:
+    resolution: { integrity: sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU= }
+    dev: false
+
+  /sha.js/2.2.6:
+    resolution: { integrity: sha1-F93t3F9yL7ZlAWWIlUYZd4ZzFbo= }
+    hasBin: true
+    dev: false
+
+  /snapdragon-node/2.1.1:
+    resolution: { integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      define-property: 1.0.0
+      isobject: 3.0.1
+      snapdragon-util: 3.0.1
+    dev: false
+
+  /snapdragon-util/3.0.1:
+    resolution: { integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /snapdragon/0.8.2:
+    resolution: { integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      base: 0.11.2
+      debug: 2.6.9
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      map-cache: 0.2.2
+      source-map: 0.5.7
+      source-map-resolve: 0.5.3
+      use: 3.1.1
+    dev: false
+
+  /source-list-map/0.1.8:
+    resolution: { integrity: sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY= }
+    dev: false
+
+  /source-map-resolve/0.5.3:
+    resolution: { integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw== }
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
+    dependencies:
+      atob: 2.1.2
+      decode-uri-component: 0.2.0
+      resolve-url: 0.2.1
+      source-map-url: 0.4.1
+      urix: 0.1.0
+    dev: false
+
+  /source-map-url/0.4.1:
+    resolution: { integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw== }
+    deprecated: See https://github.com/lydell/source-map-url#deprecated
+    dev: false
+
+  /source-map/0.4.4:
+    resolution: { integrity: sha1-66T12pwNyZneaAMti092FzZSA2s= }
+    engines: { node: '>=0.8.0' }
+    dependencies:
+      amdefine: 1.0.1
+    dev: false
+
+  /source-map/0.5.7:
+    resolution: { integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w= }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /split-string/3.1.0:
+    resolution: { integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      extend-shallow: 3.0.2
+    dev: false
+
+  /static-extend/0.1.2:
+    resolution: { integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      define-property: 0.2.5
+      object-copy: 0.1.0
+    dev: false
+
+  /stream-browserify/2.0.2:
+    resolution: { integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg== }
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.7
+    dev: false
+
+  /stream-http/2.8.3:
+    resolution: { integrity: sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw== }
+    dependencies:
+      builtin-status-codes: 3.0.0
+      inherits: 2.0.4
+      readable-stream: 2.3.7
+      to-arraybuffer: 1.0.1
+      xtend: 4.0.2
+    dev: false
+
+  /string_decoder/0.10.31:
+    resolution: { integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ= }
+    dev: false
+
+  /string_decoder/1.1.1:
+    resolution: { integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg== }
+    dependencies:
+      safe-buffer: 5.1.2
+    dev: false
+
+  /supports-color/3.2.3:
+    resolution: { integrity: sha1-ZawFBLOVQXHYpklGsq48u4pfVPY= }
+    engines: { node: '>=0.8.0' }
+    dependencies:
+      has-flag: 1.0.0
+    dev: false
+
+  /tapable/0.1.10:
+    resolution: { integrity: sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q= }
+    engines: { node: '>=0.6' }
+    dev: false
+
+  /timers-browserify/2.0.12:
+    resolution: { integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ== }
+    engines: { node: '>=0.6.0' }
+    dependencies:
+      setimmediate: 1.0.5
+    dev: false
+
+  /tiny-emitter/2.1.0:
+    resolution: { integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q== }
+    dev: false
+
+  /to-arraybuffer/1.0.1:
+    resolution: { integrity: sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M= }
+    dev: false
+
+  /to-object-path/0.3.0:
+    resolution: { integrity: sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      kind-of: 3.2.2
+    dev: false
+
+  /to-regex-range/2.1.1:
+    resolution: { integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      is-number: 3.0.0
+      repeat-string: 1.6.1
+    dev: false
+
+  /to-regex/3.0.2:
+    resolution: { integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      regex-not: 1.0.2
+      safe-regex: 1.1.0
+    dev: false
+
+  /tty-browserify/0.0.0:
+    resolution: { integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY= }
+    dev: false
+
+  /typed-function/2.0.0:
+    resolution: { integrity: sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA== }
+    engines: { node: '>= 8' }
+    dev: false
+
+  /uglify-js/2.7.5:
+    resolution: { integrity: sha1-RhLAx7qu4rp8SH3kkErhIgefLKg= }
+    engines: { node: '>=0.8.0' }
+    hasBin: true
+    dependencies:
+      async: 0.2.10
+      source-map: 0.5.7
+      uglify-to-browserify: 1.0.2
+      yargs: 3.10.0
+    dev: false
+
+  /uglify-to-browserify/1.0.2:
+    resolution: { integrity: sha1-bgkk1r2mta/jSeOabWMoUKD4grc= }
+    dev: false
+
+  /union-value/1.0.1:
+    resolution: { integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg== }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      arr-union: 3.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      set-value: 2.0.1
+    dev: false
+
+  /unset-value/1.0.0:
+    resolution: { integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk= }
+    engines: { node: '>=0.10.0' }
+    dependencies:
+      has-value: 0.3.1
+      isobject: 3.0.1
+    dev: false
+
+  /urix/0.1.0:
+    resolution: { integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI= }
+    deprecated: Please see https://github.com/lydell/urix#deprecated
+    dev: false
+
+  /url/0.11.0:
+    resolution: { integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE= }
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
+
+  /use/3.1.1:
+    resolution: { integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ== }
+    engines: { node: '>=0.10.0' }
+    dev: false
+
+  /util-deprecate/1.0.2:
+    resolution: { integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= }
+    dev: false
+
+  /util/0.10.3:
+    resolution: { integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk= }
+    dependencies:
+      inherits: 2.0.1
+    dev: false
+
+  /util/0.10.4:
+    resolution: { integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A== }
+    dependencies:
+      inherits: 2.0.3
+    dev: false
+
+  /vm-browserify/0.0.4:
+    resolution: { integrity: sha1-XX6kW7755Kb/ZflUOOCofDV9WnM= }
+    dependencies:
+      indexof: 0.0.1
+    dev: false
+
+  /vxe-table/4.1.20_vue@3.2.27+xe-utils@3.5.4:
+    resolution: { integrity: sha512-/f9wfm2XczZGVQINwIyi93JdZVt/ttl+GzcByA7TlDEd+sMRYBCkyljy5mOcdEe8haBZDmK2/eUDPHbOg6lxdA== }
+    peerDependencies:
+      vue: ^3.2.2
+      xe-utils: ^3.5.0
+    dependencies:
+      vue: registry.npmmirror.com/vue/3.2.27
+      xe-utils: 3.5.4
+    dev: false
+
+  /watchpack/0.2.9:
+    resolution: { integrity: sha1-Yuqkq15bo1/fwBgnVibjwPXj+ws= }
+    dependencies:
+      async: 0.9.2
+      chokidar: 1.7.0
+      graceful-fs: 4.2.9
+    dev: false
+
+  /webpack-core/0.6.9:
+    resolution: { integrity: sha1-/FcViMhVjad76e+23r3Fo7FyvcI= }
+    engines: { node: '>=0.6' }
+    dependencies:
+      source-list-map: 0.1.8
+      source-map: 0.4.4
+    dev: false
+
+  /webpack-env/0.8.0:
+    resolution: { integrity: sha1-l3cbOczQ5TLbHIfUWTecnXzYh9w= }
+    dependencies:
+      webpack: 1.15.0
+    dev: false
+
+  /webpack/1.15.0:
+    resolution: { integrity: sha1-T/MfU9sDM55VFkqdRo7gMklo/pg= }
+    engines: { node: '>=0.6' }
+    hasBin: true
+    dependencies:
+      acorn: 3.3.0
+      async: 1.5.2
+      clone: 1.0.4
+      enhanced-resolve: 0.9.1
+      interpret: 0.6.6
+      loader-utils: 0.2.17
+      memory-fs: 0.3.0
+      mkdirp: 0.5.5
+      node-libs-browser: 0.7.0
+      optimist: 0.6.1
+      supports-color: 3.2.3
+      tapable: 0.1.10
+      uglify-js: 2.7.5
+      watchpack: 0.2.9
+      webpack-core: 0.6.9
+    dev: false
+
+  /window-size/0.1.0:
+    resolution: { integrity: sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0= }
+    engines: { node: '>= 0.8.0' }
+    dev: false
+
+  /wordwrap/0.0.2:
+    resolution: { integrity: sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8= }
+    engines: { node: '>=0.4.0' }
+    dev: false
+
+  /wordwrap/0.0.3:
+    resolution: { integrity: sha1-o9XabNXAvAAI03I0u68b7WMFkQc= }
+    engines: { node: '>=0.4.0' }
+    dev: false
+
+  /xe-utils/3.5.4:
+    resolution: { integrity: sha512-oH7VOgvHv34pn198dhKPVKnuEHV22Q06YpCTVnAS3JuutylmZj/rtJGvn0BxxWQ37w2LgCknoebLA4uIGXwFtw== }
+    dev: false
+
+  /xtend/4.0.2:
+    resolution: { integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ== }
+    engines: { node: '>=0.4' }
+    dev: false
+
+  /yargs/3.10.0:
+    resolution: { integrity: sha1-9+572FfdfB0tOMDnTvvWgdFDH9E= }
+    dependencies:
+      camelcase: 1.2.1
+      cliui: 2.1.0
+      decamelize: 1.2.0
+      window-size: 0.1.0
+    dev: false
+
   registry.nlark.com/@ant-design/colors/5.1.1:
     resolution:
       { integrity: sha1-gAshhrHifmZDLmfQPtlq8+IdiUA=, registry: http://registry.npm.taobao.org/, tarball: https://registry.nlark.com/@ant-design/colors/download/@ant-design/colors-5.1.1.tgz }

--- a/src/.pnpm-debug.log
+++ b/src/.pnpm-debug.log
@@ -1,0 +1,19 @@
+{
+  "0 debug pnpm:scope": {
+    "selected": 1
+  },
+  "1 error pnpm": {
+    "errno": 1,
+    "code": "ELIFECYCLE",
+    "pkgid": "vite-template-vue3-ts@0.0.0",
+    "stage": "dev",
+    "script": "pnpm prettier && pnpm lint:development && vite --host --mode development",
+    "pkgname": "vite-template-vue3-ts",
+    "err": {
+      "name": "Error",
+      "message": "vite-template-vue3-ts@0.0.0 dev: `pnpm prettier && pnpm lint:development && vite --host --mode development`\nExit status 1",
+      "code": "ELIFECYCLE",
+      "stack": "Error: vite-template-vue3-ts@0.0.0 dev: `pnpm prettier && pnpm lint:development && vite --host --mode development`\nExit status 1\n    at EventEmitter.<anonymous> (/home/liukairui/.node/corepack/pnpm/6.11.0/dist/pnpm.cjs:104774:20)\n    at EventEmitter.emit (node:events:390:28)\n    at ChildProcess.<anonymous> (/home/liukairui/.node/corepack/pnpm/6.11.0/dist/pnpm.cjs:93080:18)\n    at ChildProcess.emit (node:events:390:28)\n    at maybeClose (node:internal/child_process:1062:16)\n    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5)"
+    }
+  }
+}

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -3,21 +3,29 @@
 // Read more: https://github.com/vuejs/vue-next/pull/3399
 
 declare module 'vue' {
-	export interface GlobalComponents {
-		AAvatar: typeof import('ant-design-vue/es')['Avatar'];
-		ACard: typeof import('ant-design-vue/es')['Card'];
-		ACol: typeof import('ant-design-vue/es')['Col'];
-		ALayout: typeof import('ant-design-vue/es')['Layout'];
-		ALayoutContent: typeof import('ant-design-vue/es')['LayoutContent'];
-		ALayoutFooter: typeof import('ant-design-vue/es')['LayoutFooter'];
-		ALayoutHeader: typeof import('ant-design-vue/es')['LayoutHeader'];
-		AMenu: typeof import('ant-design-vue/es')['Menu'];
-		AMenuItem: typeof import('ant-design-vue/es')['MenuItem'];
-		ARow: typeof import('ant-design-vue/es')['Row'];
-		ATable: typeof import('ant-design-vue/es')['Table'];
-		CodeEditor: typeof import('./components/CodeEditor.vue')['default'];
-		HelloWorld: typeof import('./components/HelloWorld.vue')['default'];
-	}
+  export interface GlobalComponents {
+    AAvatar: typeof import('ant-design-vue/es')['Avatar']
+    AButton: typeof import('ant-design-vue/es')['Button']
+    ACol: typeof import('ant-design-vue/es')['Col']
+    AForm: typeof import('ant-design-vue/es')['Form']
+    AFormItem: typeof import('ant-design-vue/es')['FormItem']
+    AInput: typeof import('ant-design-vue/es')['Input']
+    ALayout: typeof import('ant-design-vue/es')['Layout']
+    ALayoutContent: typeof import('ant-design-vue/es')['LayoutContent']
+    ALayoutFooter: typeof import('ant-design-vue/es')['LayoutFooter']
+    ALayoutHeader: typeof import('ant-design-vue/es')['LayoutHeader']
+    AMenu: typeof import('ant-design-vue/es')['Menu']
+    AMenuItem: typeof import('ant-design-vue/es')['MenuItem']
+    AModal: typeof import('ant-design-vue/es')['Modal']
+    ARadio: typeof import('ant-design-vue/es')['Radio']
+    ARadioGroup: typeof import('ant-design-vue/es')['RadioGroup']
+    ARow: typeof import('ant-design-vue/es')['Row']
+    ASelect: typeof import('ant-design-vue/es')['Select']
+    ASwitch: typeof import('ant-design-vue/es')['Switch']
+    ATable: typeof import('ant-design-vue/es')['Table']
+    CodeEditor: typeof import('./components/CodeEditor.vue')['default']
+    HelloWorld: typeof import('./components/HelloWorld.vue')['default']
+  }
 }
 
-export {};
+export { }

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,6 +1,6 @@
 const configs = {
 	baseUrl: '/api',
-	proxyUrl: 'https://datavis.all1024.com',
+	proxyUrl: 'localhost:9000',
 };
 
 export default configs;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
+import 'xe-utils';
+import VXETable from 'vxe-table';
+import 'vxe-table/lib/style.css';
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';
 import router from './router';
+import 'default-passive-events';
 
-createApp(App).use(router).use(createPinia()).mount('#app');
+createApp(App).use(router).use(createPinia()).use(VXETable).mount('#app');

--- a/src/pages/preproccess/index.vue
+++ b/src/pages/preproccess/index.vue
@@ -1,0 +1,133 @@
+<template>
+	<header>
+		<a-row>
+			<a-col :span="3"> 选定数据源 </a-col>
+			<a-col :span="9"> {{ table.title }} </a-col>
+		</a-row>
+	</header>
+	<section id="tableSelects">
+		<div id="TableEditor">
+			<TableEditor></TableEditor>
+		</div>
+		<div id="FieldSelect">
+			<FieldSelect></FieldSelect>
+		</div>
+	</section>
+	<section id="FiledDefs">
+		<FieldDefine></FieldDefine>
+	</section>
+	<section id="tableSubmit">
+		<a-button type="primary" @click="showModal(0)">下一步</a-button>
+		<a-button type="primary" @click="showModal(1)">保存表格</a-button>
+	</section>
+	<div>
+		<a-modal v-model:visible="state.expVis" title="使用哪些数据?" @ok="nextStep">
+			<a-form>
+				<a-form-item label="使用选定数据?">
+					<a-radio-group v-model:value="state.save1">
+						<a-radio :value="true">使用选定的字段</a-radio>
+						<a-radio :value="false">使用全部字段</a-radio>
+					</a-radio-group>
+				</a-form-item>
+				<a-form-item label="使用筛选后数据?">
+					<a-radio-group v-model:value="state.save2">
+						<a-radio :value="true">使用筛选后数据</a-radio>
+						<a-radio :value="false">使用全部数据</a-radio>
+					</a-radio-group>
+				</a-form-item>
+			</a-form>
+		</a-modal>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, reactive } from 'vue';
+import { message, notification } from 'ant-design-vue';
+import { useTableStore } from '../../store/process';
+import TableEditor from './preproccess/TableEditor.vue';
+import FieldSelect from './preproccess/FieldSelect.vue';
+import FieldDefine from './preproccess/FieldDefine.vue';
+
+const store = useTableStore();
+const { table } = store;
+
+// 请求表格
+onMounted(async () => {
+	if (!(await store.getTable())) {
+		notification.open({
+			message: '网络错误',
+			description: '请求数据失败, 请检查你的网络.',
+			duration: 0,
+		});
+	}
+});
+
+// 下一步模态框状态
+const state = reactive({
+	expVis: false,
+	save1: false,
+	save2: true,
+	curType: 0,
+});
+
+// 显示下一步模态框
+function showModal(type: number) {
+	state.curType = type;
+	state.expVis = true;
+}
+
+// 下一步与保存数据按钮
+function nextStep() {
+	if (table.cols.find(d => !d.computed && d?.errors?.haveError)) {
+		message.error('存在有误数据, 无法继续');
+		state.expVis = false;
+		return;
+	}
+	store.tableExport = table.exportTable(state.save1, state.save2);
+	if (state.curType) {
+		store.putTable().then(
+			() => {
+				message.success('保存成功');
+			},
+			() => {
+				message.error('保存失败');
+			}
+		);
+	}
+}
+</script>
+<style lang="less" scoped>
+* {
+	box-sizing: border-box;
+}
+
+header {
+	height: 10%;
+}
+
+#tableSelects {
+	max-height: 50%;
+	display: flex;
+	#TableEditor {
+		padding: 3vh 2vw;
+		width: 70%;
+		overflow: auto;
+	}
+	#FieldSelect {
+		padding: 3vh 2vw;
+		width: 30%;
+		overflow: auto;
+	}
+}
+
+#FiledDefs {
+	height: 30%;
+	padding: 3vh 2vw;
+}
+
+#tableSubmit {
+	height: 10%;
+	display: flex;
+	flex-direction: row-reverse;
+}
+</style>

--- a/src/pages/preproccess/preproccess/FieldDefine.vue
+++ b/src/pages/preproccess/preproccess/FieldDefine.vue
@@ -1,0 +1,127 @@
+<template>
+	<div class="title">
+		<h3>定义您的数据</h3>
+	</div>
+	<a-table :row-key="record => record.cid" :pagination="false" :columns="colName" :data-source="colData">
+		<template #defineType="{ record }">
+			<a-select ref="select" v-model:value="record.type" :options="colType" @change="typeChange(record)"> </a-select>
+		</template>
+		<template #defineRange="{ record }">
+			<a-button type="primary" @click="toggleOnEdit(record.cid, 'dataDef')">点击定义</a-button>
+			<FieldSift :col-id="record.cid" modal-type="dataDef"></FieldSift>
+		</template>
+		<template #defineSift="{ record }">
+			<a-button type="primary" @click="toggleOnEdit(record.cid, 'dataSift')">点击筛选</a-button>
+			<FieldSift :col-id="record.cid" modal-type="dataSift"> </FieldSift>
+		</template>
+		<template #errors="{ record }">
+			{{ errInfo(record) }}
+		</template>
+	</a-table>
+</template>
+
+<script lang="ts" setup>
+import { computed, reactive } from 'vue';
+import FieldSift from './FieldSift.vue';
+import { useTableStore } from '../../../store/process';
+import { ProTable } from './ProTable';
+
+const colDefTableName = [
+	{
+		title: '字段',
+		dataIndex: 'cname',
+		key: 'cname',
+	},
+	{
+		title: '数据类型',
+		slots: { customRender: 'defineType' },
+		key: 'defineType',
+	},
+	{
+		title: '数据定义',
+		slots: { customRender: 'defineRange' },
+		key: 'defineRange',
+	},
+	{
+		title: '筛选',
+		slots: { customRender: 'defineSift' },
+		key: 'defineSift',
+	},
+	{
+		title: '错误',
+		slots: { customRender: 'errors' },
+		key: 'errors',
+	},
+];
+
+const store = useTableStore();
+const table = reactive(store.table);
+// 获取所有被选中的字段
+const colData = computed(() => table.cols.filter(d => d.selected));
+const colName = colDefTableName;
+// 生成数据类型options
+const colType = reactive(
+	ProTable.colType.map(d => ({
+		value: d,
+		label: d,
+	}))
+);
+
+// 开关模态框
+function toggleOnEdit(colId: number, modalType: string) {
+	const record: any = table.cols.find((d: any) => d.cid === colId);
+	if (!record) return;
+	record[modalType].onEdit = !record[modalType].onEdit;
+}
+
+// 修改数据类型并检查
+function typeChange(record: any) {
+	record.initColDefine();
+	record.initColSift();
+	record.errors.typeErr = record.checkType();
+	record.errors.haveError = record.errors.haveError || record.errors.typeErr;
+}
+
+// 生成错误信息
+function errInfo(record: any) {
+	if (!record.errors.haveError) return '未检查到错误';
+	let res = ``;
+	if (record.errors.typeErr) res += `不能定义为${record.type}类型`;
+	if (record.errors?.maxErr?.size) {
+		res += res.length ? ' / ID=' : 'ID=';
+		record.errors.maxErr.forEach((d: any) => {
+			res += `${d} `;
+		});
+		res += `大于最大值\n`;
+	}
+	if (record.errors?.minErr?.size) {
+		res += res.length ? ' / ID=' : 'ID=';
+		record.errors.minErr.forEach((d: any) => {
+			res += `${d} `;
+		});
+		res += `小于最小值\n`;
+	}
+	if (record.errors?.nnErr?.size) {
+		res += res.length ? ' / ID=' : 'ID=';
+		record.errors.nnErr.forEach((d: any) => {
+			res += `${d} `;
+		});
+		res += `存在空值`;
+	}
+	return res;
+}
+</script>
+
+<script lang="ts">
+export default {
+	name: 'FieldDefine',
+};
+</script>
+
+<style lang="less" scoped>
+.title {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+</style>

--- a/src/pages/preproccess/preproccess/FieldSelect.vue
+++ b/src/pages/preproccess/preproccess/FieldSelect.vue
@@ -1,0 +1,250 @@
+<template>
+	<div class="title">
+		<h3>选择您需要的数据</h3>
+		<a-button type="primary" ghost @click="toggleCompModal"><PlusOutlined />计算属性</a-button>
+	</div>
+	<a-table :row-key="record => record.cid" :pagination="false" :row-selection="rowSelection" :columns="colName" :data-source="colData">
+		<template #name="{ text }">
+			<a>{{ text }}</a>
+		</template>
+	</a-table>
+	<div>
+		<a-modal v-model:visible="state.showCompModal" title="定义计算属性列" @ok="submitComp">
+			<a-form :label-col="{ span: 4 }" :wrapper-col="{ span: 14 }">
+				<a-form-item label="字段名">
+					<a-input v-model:value="state.compTitle" />
+				</a-form-item>
+				<a-form-item label="表达式">
+					<a-select v-model:value="state.rawEquation" :options="state.compCols" mode="multiple" placeholder="Please select" style="width: 200px" @change="addColTag" @dropdownVisibleChange="addSelec">
+					</a-select>
+				</a-form-item>
+			</a-form>
+			注: 只有number, date, boolean类型数据支持参与运算
+		</a-modal>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { computed, reactive, nextTick } from 'vue';
+import { PlusOutlined } from '@ant-design/icons-vue';
+import { message } from 'ant-design-vue';
+import { useTableStore } from '../../../store/process';
+
+interface Istate {
+	showCompModal: boolean; // 展示计算属性定义模态框
+	compTitle: string; // 计算属性字段名
+	compEquation: string; // 计算属性表达式
+	rawEquation: string[]; // 计算属性原始表达式(数组形式)
+	lastSelect: string[]; // 上一次的表达式(用户修改表达式后diff得到修改了哪项)
+	compCols: any[]; // 可参与计算的列
+	opsCount: number; // 列选项id计数
+}
+
+// 表格字段定义
+const colTableName = [
+	{
+		title: '字段',
+		dataIndex: 'title',
+		key: 'title',
+	},
+	{
+		title: '示例',
+		dataIndex: 'demo',
+		key: 'demo',
+	},
+];
+
+const store = useTableStore();
+const { table } = store;
+
+// 表格数据
+const colData = computed(() =>
+	table.cols.map(d => ({
+		cid: d.cid,
+		title: d.cname,
+		demo: d.computed ? `=${d.equation}` : table.data[0][d.cKey],
+	}))
+);
+
+const colName = colTableName;
+
+// 字段被勾选后回调(初始化筛选与定义)
+const rowSelection = {
+	onChange: (_: any, selectedRows: any) => {
+		table.cols.forEach(d => {
+			// 找到被选中并且之前没有标记选中的一列, 初始化定义与筛选
+			const t = selectedRows.find((dd: any) => dd.cid === d.cid);
+			// eslint-disable-next-line
+			if (!!t !== d.selected) {
+				d.selected = !d.selected;
+				if (d.selected === false) {
+					d.initColDefine();
+					d.initColSift();
+				}
+			}
+		});
+	},
+	getCheckboxProps: (record: any): any => {
+		const t = table.cols.find(d => d.cid === record.cid);
+		if (t?.computed) return { checked: true, disabled: true };
+		return {};
+	},
+};
+
+const state: Istate = reactive({
+	showCompModal: false,
+	compTitle: '',
+	compEquation: '',
+	rawEquation: [],
+	lastSelect: [],
+	compCols: [],
+	opsCount: 0,
+});
+
+/**
+ * @description 下面都在封装这个奇怪的多选组件(但是懒得抽象成组件了
+ * @param v 用户修改select后的值
+ */
+
+function addColTag(v: string[]) {
+	let remove = false;
+	let changeItem: string | null = null;
+	// 与上一次对比看看判断修改了那个元素, 是增加了还是删除了
+	state.lastSelect.forEach(d => {
+		if (!v.includes(d)) {
+			remove = true;
+			changeItem = d;
+		}
+	});
+	if (!remove)
+		v.forEach(d => {
+			if (!state.lastSelect.includes(d)) {
+				changeItem = d;
+			}
+		});
+	// 如果是删除了元素, 就把他从多选框中删除(因为还有同名列)
+	if (remove) {
+		const idx = state.compCols.findIndex(d => d.value === changeItem);
+		if (idx + 1) state.compCols.splice(idx, 1);
+	} else {
+		// 如果是增加了列就比较麻烦, 为了让新的同名字段与原来同名字段同序, 稍微处理一下, 获取需要添加字段位置, 生成添加字段
+		const idx = state.compCols.findIndex(d => d.value === changeItem);
+		const newItem = reactive({
+			value: state.compCols[idx].value,
+			label: state.compCols[idx].label,
+		});
+		if (/F-\d+$/.test(newItem.value)) {
+			// eslint-disable-next-line
+			newItem.value = newItem.value.replace(/F-\d+$/, `F-${state.opsCount++}`);
+		} else {
+			// eslint-disable-next-line
+			newItem.value = newItem.value.replace(/\d+$/, `${state.opsCount++}`);
+		}
+		if (idx + 1) {
+			//! 为了保证options不变顺序, 不破坏proxy只能这样搞
+			let len = state.compCols.length;
+			state.compCols.push(...state.compCols.slice(0, idx + 1), newItem, ...state.compCols.slice(idx + 1));
+			// eslint-disable-next-line
+			while (len--) state.compCols.shift();
+		}
+	}
+	state.lastSelect = v;
+}
+
+// 当option被选中需要屏蔽掉被选中option, 需要加入一个tag防止污染全局
+function addSelec() {
+	nextTick(() => {
+		// ! antd会在列表元素被选择后重新构造列表? 不要使用toggle
+		if (state.showCompModal) document.querySelectorAll('.ant-select-dropdown').forEach(d => d.classList.add('mulTagSelect'));
+		else document.querySelectorAll('.ant-select-dropdown').forEach(d => d.classList.remove('mulTagSelect'));
+	});
+}
+
+// 存储计算属性表达式
+function submitComp() {
+	if (state.compTitle.trim().length === 0 && state.showCompModal) {
+		message.error('字段名不能为空');
+		return;
+	}
+	// 正则将变量转为 $变量$形式, 符号不变
+	state.compEquation = state.rawEquation
+		.map(d => {
+			let t = d;
+			if (/-F-\d+$/.test(t)) {
+				t = t.replace(/-F-\d+$/, '');
+			} else {
+				t = `$${t}`;
+				t = t.replace(/-\d+$/, '$');
+			}
+			return t;
+		})
+		.join('');
+	// 增加计算属性列
+	table.addComputedValue({
+		equation: state.compEquation,
+		cname: state.compTitle,
+	});
+	toggleCompModal();
+}
+
+// 每次开关模态框的时候
+function toggleCompModal() {
+	// 初始化各种各样数据
+	state.showCompModal = !state.showCompModal;
+	state.opsCount = 0;
+	state.rawEquation = [];
+	state.compEquation = '';
+	state.compTitle = '';
+	state.lastSelect = [];
+	// 增加计算属性列, 增加计算符号列
+	/* eslint-disable */
+	state.compCols = table.cols.filter(d => !d.computed && d.compareable).map(d => ({ value: `${d.cKey}-${state.opsCount++}`, label: d.cname }));
+	state.compCols.push(
+		{ value: `(-F-${state.opsCount++}`, label: '(' },
+		{ value: `)-F-${state.opsCount++}`, label: ')' },
+		{ value: `--F-${state.opsCount++}`, label: '-' },
+		{ value: `+-F-${state.opsCount++}`, label: '+' },
+		{ value: `*-F-${state.opsCount++}`, label: '*' },
+		{ value: `/-F-${state.opsCount++}`, label: '/' },
+		{ value: `^-F-${state.opsCount++}`, label: '^' },
+		{ value: `&-F-${state.opsCount++}`, label: '&' },
+		{ value: `|-F-${state.opsCount++}`, label: '|' },
+		{ value: `<<-F-${state.opsCount++}`, label: '<<' },
+		{ value: `>>-F-${state.opsCount++}`, label: '>>' },
+		{ value: `>>>-F-${state.opsCount++}`, label: '>>>' },
+		{ value: `sqrt-F-${state.opsCount++}`, label: 'sqrt' },
+		{ value: `sin-F-${state.opsCount++}`, label: 'sin' },
+		{ value: `cos-F-${state.opsCount++}`, label: 'cos' },
+		{ value: `tan-F-${state.opsCount++}`, label: 'tan' },
+		{ value: `pi-F-${state.opsCount++}`, label: 'pi' },
+		{ value: `e-F-${state.opsCount++}`, label: 'e' }
+	);
+	/* eslint-enable */
+}
+</script>
+
+<script lang="ts">
+export default {
+	name: 'FieldSelect',
+};
+</script>
+
+<style lang="less" scoped>
+.title {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
+</style>
+
+<style>
+.mulTagSelect .ant-select-item-option[aria-selected='true'] {
+	appearance: none !important;
+	box-sizing: border-box !important;
+	height: 0 !important;
+	visibility: hidden !important;
+	margin: 0 !important;
+	display: none !important;
+	/* background-color: #bfa; */
+}
+</style>

--- a/src/pages/preproccess/preproccess/FieldSift.vue
+++ b/src/pages/preproccess/preproccess/FieldSift.vue
@@ -1,0 +1,96 @@
+<template>
+	<a-modal v-model:visible="recordData.onEdit" :title="title">
+		<template v-if="modalType === 'dataDef'" #footer>
+			<a-button key="reset" @click="initDef">重置</a-button>
+			<a-button key="back" type="primary" @click="checkDef">确定</a-button>
+		</template>
+		<template v-else #footer>
+			<a-button key="reset" @click="initSift">重置</a-button>
+			<a-button key="back" type="primary" @click="toSift">确定</a-button>
+		</template>
+		<a-form v-if="modalType === 'dataDef'" :model="recordData" :label-col="{ span: 4 }" :wrapper-col="{ span: 14 }">
+			<a-form-item label="最大值">
+				<a-input v-model:value="recordData.max" :disabled="!isCompareable" @change="defFlag" />
+			</a-form-item>
+			<a-form-item label="最小值">
+				<a-input v-model:value="recordData.min" :disabled="!isCompareable" @change="defFlag" />
+			</a-form-item>
+			<a-form-item label="非空">
+				<a-switch v-model:checked="recordData.nn" @change="defFlag" />
+			</a-form-item>
+		</a-form>
+		<a-form v-else :model="recordData" :label-col="{ span: 4 }" :wrapper-col="{ span: 14 }">
+			<a-form-item label="最大值">
+				<a-input v-model:value="recordData.max" :disabled="!isCompareable" @change="defSift" />
+			</a-form-item>
+			<a-form-item label="最小值">
+				<a-input v-model:value="recordData.min" :disabled="!isCompareable" @change="defSift" />
+			</a-form-item>
+			<a-form-item label="前百分之(%)">
+				<a-input v-model:value="recordData.top" :disabled="!isCompareable" @change="defSift" />
+			</a-form-item>
+			<a-form-item label="后百分之(%)">
+				<a-input v-model:value="recordData.last" :disabled="!isCompareable" @change="defSift" />
+			</a-form-item>
+			<a-form-item label="非空">
+				<a-switch v-model:checked="recordData.nn" @change="defSift" />
+			</a-form-item>
+		</a-form>
+	</a-modal>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+
+import { useTableStore } from '../../../store/process';
+
+const props = defineProps({
+	colId: { type: Number, required: true },
+	modalType: { type: String, required: true },
+});
+const store = useTableStore();
+const { table } = store;
+
+// 模态框类型
+// eslint-disable-next-line
+const { modalType } = props;
+// 字段对象
+const recordCol = table.cols.find(d => d.cid === props.colId) || null;
+// 字段筛选与定义状态
+const recordData = recordCol ? recordCol[modalType] : null;
+// 模态框标题
+const title = computed(() => (modalType === 'dataDef' ? '定义您的数据' : '筛选您的数据'));
+// 字段是否是可比较属性(如果不可比较仅支持非空定义与筛选)
+const isCompareable = computed(() => (recordCol ? recordCol.compareable : null));
+// 初始化数据定义状态
+function initDef() {
+	recordCol?.initColDefine();
+}
+// 初始化数据筛选状态
+function initSift() {
+	recordCol?.initColSift();
+}
+// 检查用户的定义是否合法
+function checkDef() {
+	recordCol?.checkColDefine();
+	if (recordCol) recordCol.dataDef.onEdit = false;
+}
+// 打开数据筛选框
+function toSift() {
+	if (recordCol) recordCol.dataSift.onEdit = false;
+}
+// 标记定义状态被修改
+function defFlag() {
+	if (recordCol) recordCol.dataDef.defed = true;
+}
+// 标记筛选状态被修改
+function defSift() {
+	if (recordCol) recordCol.dataSift.defed = true;
+}
+</script>
+
+<script lang="ts">
+export default {
+	name: 'FieldSift',
+};
+</script>

--- a/src/pages/preproccess/preproccess/ProTable.ts
+++ b/src/pages/preproccess/preproccess/ProTable.ts
@@ -1,0 +1,348 @@
+/* eslint max-classes-per-file: ["error", 99] */
+// 这个文件有点大, 不想分文件了
+
+import { evaluate } from 'mathjs';
+
+// 列上错误记录
+interface IColErr {
+	haveError: boolean; // 有错误
+	maxErr?: any; // 有值大于最大值(Set(colId))
+	minErr?: any; // 有值小于最小值(Set(colId))
+	nnErr?: any; // 有值为空值(要求为非空)(Set(colId))
+	typeErr?: boolean; // 数据类型不合法
+}
+
+/**
+ * @description 数据类型或筛选用属性
+ */
+export class TableColDataDef {
+	onEdit: boolean; // 编辑中
+
+	defed: boolean; // 用户手动修改过
+
+	min: any; // 最小值
+
+	max: any; // 最大值
+
+	nn: boolean; // 非空?
+
+	top: number | null; // 前百分之多少
+
+	last: number | null; // 后百分之多少
+
+	topV: number | null; // 前百分之多少对应多大
+
+	lastV: number | null; // 后百分之多少对应多大
+
+	constructor({ onEdit = false, defed = false, min = null, max = null, nn = true, top = null, last = null, topV = null, lastV = null }) {
+		this.onEdit = onEdit;
+		this.defed = defed;
+		this.min = min;
+		this.max = max;
+		this.nn = nn;
+		this.top = top;
+		this.last = last;
+		this.topV = topV;
+		this.lastV = lastV;
+	}
+}
+
+export class TableCol {
+	cid: number; // 列ID
+
+	computed: boolean; // 是否是计算属性字段
+
+	cname: string; // 展示的名字
+
+	cKey: string; // key
+
+	type: string; // 数据类型
+
+	equation: string | null; // 计算属性的公式
+
+	selected: boolean; // 字段被选中
+
+	dataDef: TableColDataDef; // 数据定义
+
+	dataSift: TableColDataDef; // 数据筛选
+
+	compareable: boolean; // 这个字段类型是否是可比较的(boolean date number)
+
+	data: any[]; // link到表格数据方便操作
+
+	errors: IColErr; // 列中所有error
+
+	constructor({ cid, cname, cKey, type = 'string', data, equation = null, computed = false }) {
+		this.cid = cid;
+		this.computed = computed;
+		this.cname = cname;
+		this.cKey = cKey;
+		this.type = type.trim().toLowerCase();
+		this.equation = equation;
+		this.selected = false;
+		this.dataDef = new TableColDataDef({});
+		this.dataSift = new TableColDataDef({});
+		this.compareable = false;
+		this.data = data;
+		if (!this.computed) {
+			// 如果不是计算属性就检查类型, 初始化数据定义与筛选, 计算错误
+			this.checkType();
+			this.initColDefine();
+			this.initColSift();
+			this.errors = { haveError: null, typeErr: this.checkType() };
+		} else {
+			// 计算下计算属性值
+			this.refreshComputedValue();
+		}
+	}
+
+	// 定义每一个属性的: 属性名, 判断是否是该属性函数, 重载<=, 可比较类型?
+	static colType = [
+		{
+			typeName: 'date',
+			checkType: v => !Number.isNaN(new Date(v).getTime()),
+			isLeq: (a, b) => a <= b,
+			compareable: true,
+		},
+		{
+			typeName: 'boolean',
+			checkType: v => {
+				if (['boolean', 'number'].includes(typeof v)) return true;
+				if (typeof v === 'string') return ['true', 'false'].includes(v.trim().toLowerCase());
+				return false;
+			},
+			isLeq: (a, b) => (a.trim().toLowerCase() !== 'false' && !!a) <= (b.trim().toLowerCase() !== 'false' && !!b),
+			compareable: true,
+		},
+		{
+			typeName: 'number',
+			checkType: v => !Number.isNaN(+v),
+			isLeq: (a, b) => +a <= +b,
+			compareable: true,
+		},
+		{
+			typeName: 'string',
+			checkType: () => true,
+			isLeq: () => true,
+			compareable: false,
+		},
+	];
+
+	// 获取这一列的类型对象与本列数据(v), 行ID(rowId)
+	getColTypeData() {
+		const typeObj = TableCol.colType.find(d => d.typeName === this.type.toLowerCase()) || TableCol.colType.slice(-1)[0];
+		const colData = this.data.map(d => {
+			return { v: d[this.cKey], rowId: d.rowId };
+		});
+		return { typeObj, colData };
+	}
+
+	// 检查类型
+	checkType() {
+		const { typeObj, colData } = this.getColTypeData();
+		this.compareable = typeObj.compareable;
+		return !!(colData.findIndex(d => !typeObj.checkType(d.v)) + 1);
+	}
+
+	// 初始化数据定义对象
+	initColDefine(): void {
+		const { typeObj, colData } = this.getColTypeData();
+		this.compareable = typeObj.compareable;
+		const tmpArr = [...colData];
+		tmpArr.sort((a, b) => 0.5 - (typeObj.isLeq(a.v, b.v) as unknown as number));
+		this.dataDef.nn = !(tmpArr.findIndex(d => d.v === null || d.v === undefined || d.v === '') + 1);
+		this.dataDef.min = this.compareable ? tmpArr.slice(0, 1).shift().v : null;
+		this.dataDef.max = this.compareable ? tmpArr.slice(-1).shift().v : null;
+		this.dataDef.defed = false;
+	}
+
+	// 初始化数据定义对象并检查错误
+	checkColDefine() {
+		const errs: IColErr = {
+			haveError: false,
+			maxErr: new Set(),
+			minErr: new Set(),
+			nnErr: new Set(),
+			typeErr: this.checkType(),
+		};
+		const { typeObj, colData } = this.getColTypeData();
+		colData.forEach(d => {
+			if (d.v === undefined || d.v === null || d.v === '') {
+				errs.nnErr.add(d.rowId);
+				return;
+			}
+			if (!typeObj.isLeq(d.v, this.dataDef.max)) errs.maxErr.add(d.rowId);
+			if (!typeObj.isLeq(this.dataDef.min, d.v)) errs.minErr.add(d.rowId);
+		});
+		errs.haveError = errs.maxErr.size || errs.minErr.size || errs.nnErr.size || errs.typeErr;
+		this.errors = errs;
+		return errs.haveError;
+	}
+
+	// 初始化数据筛选
+	initColSift() {
+		const { typeObj, colData } = this.getColTypeData();
+		this.compareable = typeObj.compareable;
+		const tmpArr = [...colData];
+		tmpArr.sort((a, b) => 0.5 - (typeObj.isLeq(a.v, b.v) as unknown as number));
+		this.dataSift.nn = !(tmpArr.findIndex(d => d.v === null || d.v === undefined || d.v === '') + 1);
+		this.dataSift.min = this.compareable ? tmpArr.slice(0, 1).shift().v : null;
+		this.dataSift.max = this.compareable ? tmpArr.slice(-1).shift().v : null;
+		this.dataSift.top = this.compareable ? 100 : null;
+		this.dataSift.last = this.compareable ? 100 : null;
+		this.dataSift.defed = false;
+	}
+
+	// 返回被筛选掉的数据
+	filteColSift() {
+		const { typeObj, colData } = this.getColTypeData();
+		const disableRow = [];
+		colData.forEach(d => {
+			if (this.dataSift.nn && (d.v === null || d.v === undefined || d.v === '')) {
+				disableRow.push(d.rowId);
+			} else if (this.compareable) {
+				const orderArr = [...colData];
+				orderArr.sort((a, b) => 0.5 - (typeObj.isLeq(a.v, b.v) as unknown as number));
+				if (!orderArr.length) return;
+				const lowIdx = Math.ceil((orderArr.length * this.dataSift.last) / 100 - 1);
+
+				const highIdx = orderArr.length - 1 - Math.ceil((orderArr.length * this.dataSift.last) / 100 - 1);
+
+				this.dataSift.lastV = orderArr.slice(lowIdx).length ? orderArr.slice(lowIdx)?.shift().v : orderArr.slice(0).shift().v - 1;
+				this.dataSift.topV = orderArr.slice(highIdx).length ? orderArr.slice(highIdx)?.shift().v : orderArr.slice(-1).shift().v + 1;
+				if (!(typeObj.isLeq(d.v, this.dataSift.max) && typeObj.isLeq(this.dataSift.min, d.v) && (typeObj.isLeq(d.v, this.dataSift.lastV) || typeObj.isLeq(this.dataSift.topV, d.v)))) {
+					disableRow.push(d.rowId);
+				}
+			}
+		});
+		return disableRow;
+	}
+
+	// 刷新列的计算属性值
+	refreshComputedValue() {
+		if (!this.computed) return;
+		this.data.forEach(d => {
+			let e = this.equation;
+			const numCol = e.match(/\$[^ $]+\$/g);
+			if (numCol) {
+				numCol.forEach(dd => {
+					if (Object.prototype.hasOwnProperty.call(d, dd.slice(1, -1))) e = e.replaceAll(dd, Number.parseFloat(d[dd.slice(1, -1).trim()] || 0));
+				});
+			}
+			d[this.cKey] = evaluate(e);
+		});
+	}
+}
+
+export class ProTable {
+	geted: boolean; // 成功获取
+
+	title: string; // 表名
+
+	data: any[]; // 数据
+
+	cols: TableCol[]; // 列定义
+
+	// 目前支持的数据类型
+	static colType = ['string', 'number', 'boolean', 'date'];
+
+	static rowCounter = 0; // 行计数
+
+	static colCounter = 0; // 列计数
+
+	constructor({ getted = true, title = '', data = [], cols = [] }) {
+		this.geted = getted;
+		this.title = title;
+		this.data = data;
+		// eslint-disable-next-line
+		this.data.forEach(d => (d.rowId = ProTable.rowCounter++));
+		this.cols = cols.map(d => {
+			// eslint-disable-next-line
+			ProTable.colCounter = Math.max(++ProTable.colCounter, d.cid);
+			return new TableCol(Object.assign(d, { data }));
+		});
+	}
+
+	// 新增数据
+	bind({ getted = true, title = '', data = [], cols = [] }) {
+		this.geted = getted;
+		this.title = title;
+		this.data = data;
+		// eslint-disable-next-line
+		this.data.forEach(d => (d.rowId = ProTable.rowCounter++));
+		this.cols = cols.map(d => {
+			// eslint-disable-next-line
+			ProTable.colCounter = Math.max(++ProTable.colCounter, d.cid);
+			return new TableCol(Object.assign(d, { data }));
+		});
+	}
+
+	// 获取筛选之后的数据
+	mappedTable() {
+		const disableRow = [];
+		this.cols.forEach(d => {
+			disableRow.push(...d.filteColSift());
+		});
+		const disableRowSet = new Set(disableRow);
+		const mappedData = this.data.filter(d => !disableRowSet.has(d.rowId));
+		return mappedData;
+	}
+
+	// 属性表格的计算属性
+	refreshComputedTable() {
+		this.cols.forEach(d => {
+			if (d.computed) d.refreshComputedValue();
+		});
+	}
+
+	// 添加计算属性列
+	addComputedValue({ cid = null, equation, cname, type = 'number' }) {
+		// eslint-disable-next-line
+		++ProTable.colCounter;
+		cid = cid || ProTable.colCounter;
+		const cKey = `comp${cid}`;
+		this.data.forEach(d => {
+			d[cKey] = null;
+		});
+		const ccol = new TableCol({
+			cid,
+			cname,
+			type,
+			data: this.data,
+			cKey,
+			equation,
+			computed: true,
+		});
+		this.cols.push(ccol);
+	}
+
+	// 导出数据表(用于存储/下一步)
+	exportTable(selected, shifted) {
+		const res = {
+			title: this.title,
+			data: [],
+			cols: [],
+		};
+		res.cols = this.cols.filter(d => (selected ? d.selected || d.computed : true));
+		res.cols = res.cols.map(d => ({
+			cid: d.cid,
+			cKey: d.cKey,
+			cname: d.cname,
+			type: d.type,
+		}));
+		const data = shifted ? this.mappedTable() : this.data;
+		data.forEach(d => {
+			const dataInv = {};
+			let cnt = 0;
+			res.cols.forEach(dd => {
+				if (Object.prototype.hasOwnProperty.call(d, dd.cKey)) {
+					dataInv[dd.cKey] = d[dd.cKey];
+					// eslint-disable-next-line
+					cnt++;
+				}
+			});
+			if (cnt) res.data.push(dataInv);
+		});
+		return res;
+	}
+}

--- a/src/pages/preproccess/preproccess/TableEditor.vue
+++ b/src/pages/preproccess/preproccess/TableEditor.vue
@@ -1,0 +1,71 @@
+<template>
+	<div>
+		<vxe-table class="mytable-style" :edit-config="{ trigger: 'click', mode: 'cell' }" :data="mappedTable" :cell-style="cellStyle">
+			<vxe-column :key="-1" field="rowId" title="ID"> </vxe-column>
+			<vxe-column v-for="item in table.cols.filter(d => !d.computed)" :key="item.cid" :field="item.cKey" :title="item.cname" :edit-render="{ autofocus: '.vxe-input--inner' }">
+				<template #edit="{ row }">
+					<vxe-input v-model.lazy="row[item.cKey]" @blur="reCheck(item)"></vxe-input>
+				</template>
+			</vxe-column>
+			<vxe-column v-for="item in table.cols.filter(d => d.computed)" :key="item.cid" :field="item.cKey" :title="item.cname"> </vxe-column>
+		</vxe-table>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useTableStore } from '../../../store/process';
+
+const store = useTableStore();
+const { table } = store;
+
+/**
+ *
+ * @description 表格内容修改后检查字段类型是否合法,
+ * **** 若不合法则清空数据定义, 数据筛选
+ * **** 若合法则判断数据定义与筛选是否被定义, 若被定义则不修改, 若未定义则重新计算数据定义与筛选默认值
+ * @param record Table的列
+ */
+function reCheck(record: any) {
+	record.errors.typeErr = record.checkType();
+	if (record.dataDef.defed) record.checkColDefine();
+	else record.initColDefine();
+	if (!record.dataSift.defed) record.initColSift();
+	record.errors.haveError = record.errors.haveError || record.errors.typeErr;
+	table.refreshComputedTable();
+}
+
+/**
+ * @description 筛选后的表格数据
+ */
+const mappedTable = computed(() => {
+	return table.mappedTable();
+});
+
+/**
+ * @description 非法属性标红
+ * @param param0 {行对象, 行号, 列对象, 列号}
+ */
+function cellStyle({ row, rowIndex, column, columnIndex }: any) {
+	const col = table.cols.find(d => column.field === d.cKey);
+	if (col?.errors?.haveError && (col.errors.maxErr.has(row.rowId) || col.errors.minErr.has(row.rowId) || col.errors.nnErr.has(row.rowId)))
+		return {
+			backgroundColor: '#FF6A6A',
+			color: '#fff',
+		};
+	return {};
+}
+</script>
+
+<script lang="ts">
+export default {
+	name: 'TableEditor',
+};
+</script>
+
+<style lang="less" scoped>
+/deep/ .vxe-input--inner {
+	background-color: inherit !important;
+	color: inherit !important;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,11 @@ const routes: RouteRecordRaw[] = [
 				name: '发布',
 				component: () => import('../pages/publish/index.vue'),
 			},
+			{
+				path: '/preproccess',
+				name: '数据预处理',
+				component: () => import('../pages/preproccess/index.vue'),
+			},
 		],
 	},
 ];

--- a/src/store/process.ts
+++ b/src/store/process.ts
@@ -1,0 +1,56 @@
+import { defineStore } from 'pinia';
+import createRequest from '../api/axios';
+import { ProTable } from '../pages/preproccess/preproccess/ProTable';
+
+export interface IgetTableAPI {
+	code: number;
+	data: ProTable;
+}
+
+export const useTableStore = defineStore({
+	id: 'process',
+	// table: 获取的数据, tableExport用于下一阶段处理的数据
+	state: () => ({
+		table: new ProTable({ getted: false }),
+		tableExport: null,
+	}),
+	actions: {
+		getTable() {
+			return createRequest({
+				url: '/table',
+				method: 'get',
+				params: {
+					t: Date.now(),
+					tid: 123,
+				},
+			}).then(
+				(d: IgetTableAPI | any) => {
+					if (!d.code) {
+						this.table.bind({
+							title: d.data.title,
+							data: d.data.data || [],
+							cols: d.data.cols,
+						});
+					} else {
+						this.table.getted = false;
+						return false;
+					}
+					return true;
+				},
+				() => {
+					this.table.geted = false;
+					return false;
+				}
+			);
+		},
+		putTable() {
+			return createRequest({
+				url: '/table',
+				method: 'put',
+				data: {
+					data: this.tableExport,
+				},
+			});
+		},
+	},
+});

--- a/src/types/preproccess/index.ts
+++ b/src/types/preproccess/index.ts
@@ -1,0 +1,33 @@
+// 似乎没用了, 删掉也可以
+
+export interface IcolDataDef {
+	onEdit: boolean;
+	defed: boolean;
+	min: number;
+	max: number;
+	nn: boolean;
+	top: number | null;
+	last: number | null;
+	[key: string]: any;
+}
+
+export interface ICols {
+	cid: number;
+	computed: boolean;
+	cname: string;
+	cKey: string;
+	type: string;
+	equition: string | null;
+	selected: boolean;
+	dataDef: IcolDataDef;
+	dataSift: IcolDataDef;
+	compareable: false;
+	[key: string]: any;
+}
+
+export interface ITable {
+	geted: boolean;
+	title: string | null;
+	data: any[];
+	cols: ICols[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"sourceMap": true,
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
-		"lib": ["esnext", "dom"],
+		"lib": ["esnext", "dom", "dom.iterable"],
 
 		"baseUrl": "./",
 		"paths": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,9 +31,11 @@ export default defineConfig({
 	server: {
 		proxy: {
 			'/api': {
-				target: configs.proxyUrl,
+				target: 'http://localhost:9000',
 				changeOrigin: true,
-				rewrite: path => path.replace(/^\/api/, ''),
+				rewrite: path => {
+					return path.replace(/^\/api/, '');
+				},
 			},
 		},
 	},


### PR DESCRIPTION
完成了数据预处理功能, 完成数据源版块中数据修正功能

**引入新的NPM依赖:**

- `"@ant-design/icons-vue": "^6.0.1"`: antd 图标
- `"vxe-table": "^4.1.20"`: 优秀的表格组件, 用于数据预处理中数据筛选/编辑/高亮
- `"webpack-env": "^0.8.0"`: 似乎是用来浏览器中一个奇怪的waring
- `"xe-utils": "^3.5.4"`: `vxe-table`的依赖
- `"mathjs": "^10.1.1"`: 用于计算属性中表达式解析(似乎是基于普拉斯特解析法)

**修改了公共文件**:

- `src/configs/index.ts`: Proxy一直配不起来就直接改了配置
- `src/main.ts`: 引入`vxe-table`
- `src/router/index.ts`: 加入数据预处理路由表
- `tsconfig.json`: 解决DOMList迭代报错问题
- `vite.config.ts`: Proxy一直配不起来就直接改了配置

**新增内容**

- `src/types/preproccess/index.ts`: 定义了一些类型, 但是似乎没用了

- `src/store/process.ts`: 定义了: get数据表, 存储数据表, put数据表, 导出数据表用于下一阶段

- `src/pages/preproccess/index.vue`: 定义预处理主界面, 页面其他组件有

  ```
  .
  ├── index.vue					// 预处理页面
  └── preproccess					// 其他组件
      ├── FieldDefine.vue			// 数据类型定义, 数据定义, 数据筛选, 错误信息提示
      ├── FieldSelect.vue			// 选择数据字段, 增加计算属性字段
      ├── FieldSift.vue			// 数据筛选与定义模态框(我也不知道为什么定义成了一个新组件)
      ├── ProTable.ts				// ProTable类, 数据标类
      └── TableEditor.vue			// 数据表格, 用于编辑, 高亮非法数据
  ```

**p.s.**

- 好久不写Vue了, 组件文件很乱, 麻烦您修改一个

**实现功能**

- 显示&编辑后端传入表格
- 对表格中字段数据进行判断(string, boolean, date, number)
- 对表格中字段数据进行定义(最大值, 最小值, 非空), 不符合定义的数据会被标出并将单元格标红
- 对表格中字段数据进行筛选(最大值, 最小值, 上分位数, 下分位数, 非空)
- 支持计算属性(对boolean, date, number)进行`+, -, *, /, sqrt, ^, >>>, >>, <<, &, sin, cos, tan`, 与常数`e, pi`(其实都是mathjs自带的, 我就是魔改了改下拉多选框, 存储了替换了改公式)
- 改了改antd的多选下拉框用于录入公式, 支持选择后不显示已选择样式, 多次选择同一个Label(可以写进PPT的点)

**已知bug**

- 麻烦为layout中`view-router`加入`max-height`我的组件是相对其设置高度的
- 改后antd的多选下拉框在多次选择同一个元素后会出现渲染异常, 下滑滚轮即可恢复

**todo**

- 与可视化同学对接数据提供方式